### PR TITLE
fix(package.json): include Samples~ directory in package build

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         "Documentation",
         "Editor",
         "Runtime",
-        "docfx.json"
+        "docfx.json",
+        "Samples~"
     ]
 }


### PR DESCRIPTION
The Samples~ directory was not included in the package build so
was being omitted from the final build.