### PR TITLE
fix(Transformation): provide deadzone value for float

### DIFF
--- a/Runtime/SharedResources/Scripts/Transformation/Conversion/CallbackContextToFloat.cs
+++ b/Runtime/SharedResources/Scripts/Transformation/Conversion/CallbackContextToFloat.cs
@@ -1,5 +1,7 @@
 namespace Tilia.Input.UnityInputSystem.Transformation.Conversion
 {
+    using Malimbe.PropertySerializationAttribute;
+    using Malimbe.XmlDocumentationAttribute;
     using System;
     using UnityEngine.Events;
     using UnityEngine.InputSystem;
@@ -16,13 +18,21 @@ namespace Tilia.Input.UnityInputSystem.Transformation.Conversion
         public class UnityEvent : UnityEvent<float> { }
 
         /// <summary>
+        /// The minimum value to consider as a zero float value.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml]
+        public float DeadZoneValue { get; set; } = 0.00001f;
+
+        /// <summary>
         /// Transforms the given input <see cref="InputAction.CallbackContext"/> to the equivalent <see cref="float"/> value.
         /// </summary>
         /// <param name="input">The value to transform.</param>
         /// <returns>The transformed value.</returns>
         protected override float Process(InputAction.CallbackContext input)
         {
-            return input.ReadValue<float>();
+            float value = input.ReadValue<float>();
+            return value >= DeadZoneValue ? value : 0f;
         }
     }
 }


### PR DESCRIPTION
There was an issue where the minimum float value for an axis
could be so low that it just wasn't reported by Unity as an action
meaning any subsequent action may not get updated due to the value
not being recognised as changed.

This fix adds in an extra deadzone value to the float that can be
used to set the absolute minimum reported value to consider as
zero.