### PR TITLE
fix(Samples): replace missing actions reference in prefab

### DIFF
--- a/Samples~/GenericXR/UnityInputSystem.Mappings.GenericXR.prefab
+++ b/Samples~/GenericXR/UnityInputSystem.Mappings.GenericXR.prefab
@@ -958,7 +958,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 62899f850307741f2a39c98a8b639597, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Actions: {fileID: -944628639613478452, guid: f9adcc3f2cca70e4fa3cdabd2c27afbc, type: 3}
+  m_Actions: {fileID: -944628639613478452, guid: 4ad928a61d9612a4685b1d2ab5c52c85, type: 3}
   m_NotificationBehavior: 2
   m_UIInputModule: {fileID: 0}
   m_DeviceLostEvent:


### PR DESCRIPTION
The GenericXR Mappings prefab had a missing reference in Actions
because the GUID was incorrect. This has now been updated.