### PR TITLE
feat(Malimbe): remove malimbe dependency

### DIFF
--- a/Runtime/FodyWeavers.xml
+++ b/Runtime/FodyWeavers.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-
-<Weavers>
-  <Malimbe.FodyRunner>
-    <AssemblyNameRegex>^Tilia.Input.UnityInputSystem</AssemblyNameRegex>
-  </Malimbe.FodyRunner>
-</Weavers>

--- a/Runtime/FodyWeavers.xml.meta
+++ b/Runtime/FodyWeavers.xml.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 2fd10e5fccd7e1e42b2fb18a0ebead33
-TextScriptImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Runtime/SharedResources/Scripts/Transformation/Conversion/CallbackContextToFloat.cs
+++ b/Runtime/SharedResources/Scripts/Transformation/Conversion/CallbackContextToFloat.cs
@@ -1,7 +1,5 @@
 namespace Tilia.Input.UnityInputSystem.Transformation.Conversion
 {
-    using Malimbe.PropertySerializationAttribute;
-    using Malimbe.XmlDocumentationAttribute;
     using System;
     using UnityEngine.Events;
     using UnityEngine.InputSystem;

--- a/Runtime/SharedResources/Scripts/Transformation/Conversion/CallbackContextTransformer.cs
+++ b/Runtime/SharedResources/Scripts/Transformation/Conversion/CallbackContextTransformer.cs
@@ -1,8 +1,7 @@
 namespace Tilia.Input.UnityInputSystem.Transformation.Conversion
 {
-    using Malimbe.PropertySerializationAttribute;
-    using Malimbe.XmlDocumentationAttribute;
     using System;
+    using UnityEngine;
     using UnityEngine.Events;
     using UnityEngine.InputSystem;
     using Zinnia.Data.Attribute;
@@ -35,12 +34,24 @@ namespace Tilia.Input.UnityInputSystem.Transformation.Conversion
             Canceled = 1 << 2
         }
 
+        [Tooltip("The ContextType event to process the transformation for.")]
+        [SerializeField]
+        [UnityFlags]
+        private ContextType contextToProcess = ContextType.Performed;
         /// <summary>
         /// The <see cref="ContextType"/> event to process the transformation for.
         /// </summary>
-        [Serialized]
-        [field: DocumentedByXml, UnityFlags]
-        public ContextType ContextToProcess { get; set; } = ContextType.Performed;
+        public ContextType ContextToProcess
+        {
+            get
+            {
+                return contextToProcess;
+            }
+            set
+            {
+                contextToProcess = value;
+            }
+        }
 
         /// <summary>
         /// Processes the given input into the output result as long as the context event is allowed to be processed based on the <see cref="ContextToProcess"/> value.

--- a/Runtime/Tilia.Input.UnityInputSystem.Runtime.asmdef
+++ b/Runtime/Tilia.Input.UnityInputSystem.Runtime.asmdef
@@ -9,10 +9,7 @@
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": true,
-    "precompiledReferences": [
-        "Malimbe.PropertySerializationAttribute.dll",
-        "Malimbe.XmlDocumentationAttribute.dll"
-    ],
+    "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
     "versionDefines": [],


### PR DESCRIPTION
BREAKING CHANGE: This removes the last remaining elements of
Malimbe and whilst it does not cause any breaking changes within
this package, it removes Malimbe as a dependency which other projects
that rely on this package may piggy back off this Malimbe dependency
so it will break any project like that.

All of the previous functionality from Malimbe has been replicated in
standard code without the need for it to be weaved by the Malimbe
helper tags.