### PR TITLE
feat(state): add ifdefs to determine whether input system is enabled

### DIFF
--- a/Documentation/API/Tracking/Velocity/InputActionPropertyVelocityTracker.md
+++ b/Documentation/API/Tracking/Velocity/InputActionPropertyVelocityTracker.md
@@ -10,24 +10,11 @@ Retrieves the velocity and angular velocity from the specified InputActionProper
 * [Fields]
   * [currentAngularVelocity]
   * [currentVelocity]
-* [Properties]
-  * [AngularVelocitySource]
-  * [VelocitySource]
 * [Methods]
-  * [AngularVelocityActionCanceled(InputAction.CallbackContext)]
-  * [AngularVelocityActionPerformed(InputAction.CallbackContext)]
-  * [BindAngularVelocityActions()]
-  * [BindVelocityActions()]
-  * [DisableAction(InputActionProperty)]
   * [DoGetAngularVelocity()]
   * [DoGetVelocity()]
-  * [EnableAction(InputActionProperty)]
   * [OnDisable()]
   * [OnEnable()]
-  * [UnbindAngularVelocityActions()]
-  * [UnbindVelocityActions()]
-  * [VelocityActionCanceled(InputAction.CallbackContext)]
-  * [VelocityActionPerformed(InputAction.CallbackContext)]
 
 ## Details
 
@@ -68,97 +55,7 @@ The current velocity.
 protected Vector3 currentVelocity
 ```
 
-### Properties
-
-#### AngularVelocitySource
-
-The InputActionProperty containing the angular velocity source.
-
-##### Declaration
-
-```
-public InputActionProperty AngularVelocitySource { get; set; }
-```
-
-#### VelocitySource
-
-The InputActionProperty containing the velocity source.
-
-##### Declaration
-
-```
-public InputActionProperty VelocitySource { get; set; }
-```
-
 ### Methods
-
-#### AngularVelocityActionCanceled(InputAction.CallbackContext)
-
-Processes the context when the angular velocity InputActionProperty is canceled.
-
-##### Declaration
-
-```
-protected virtual void AngularVelocityActionCanceled(InputAction.CallbackContext context)
-```
-
-##### Parameters
-
-| Type | Name | Description |
-| --- | --- | --- |
-| InputAction.CallbackContext | context | The action context data. |
-
-#### AngularVelocityActionPerformed(InputAction.CallbackContext)
-
-Processes the context when the angular velocity InputActionProperty is performed.
-
-##### Declaration
-
-```
-protected virtual void AngularVelocityActionPerformed(InputAction.CallbackContext context)
-```
-
-##### Parameters
-
-| Type | Name | Description |
-| --- | --- | --- |
-| InputAction.CallbackContext | context | The action context data. |
-
-#### BindAngularVelocityActions()
-
-Binds the angular velocity performed and canceled actions to the processing methods.
-
-##### Declaration
-
-```
-protected virtual void BindAngularVelocityActions()
-```
-
-#### BindVelocityActions()
-
-Binds the velocity performed and canceled actions to the processing methods.
-
-##### Declaration
-
-```
-protected virtual void BindVelocityActions()
-```
-
-#### DisableAction(InputActionProperty)
-
-Disables the given InputActionProperty.
-
-##### Declaration
-
-```
-protected virtual void DisableAction(InputActionProperty property)
-```
-
-##### Parameters
-
-| Type | Name | Description |
-| --- | --- | --- |
-| InputActionProperty | property | The property to disable. |
 
 #### DoGetAngularVelocity()
 
@@ -188,22 +85,6 @@ protected override Vector3 DoGetVelocity()
 | --- | --- |
 | Vector3 | n/a |
 
-#### EnableAction(InputActionProperty)
-
-Enables the given InputActionProperty.
-
-##### Declaration
-
-```
-protected virtual void EnableAction(InputActionProperty property)
-```
-
-##### Parameters
-
-| Type | Name | Description |
-| --- | --- | --- |
-| InputActionProperty | property | The property to enable. |
-
 #### OnDisable()
 
 ##### Declaration
@@ -220,58 +101,6 @@ protected virtual void OnDisable()
 protected virtual void OnEnable()
 ```
 
-#### UnbindAngularVelocityActions()
-
-Unbinds the velocity performed and canceled actions from the processing methods.
-
-##### Declaration
-
-```
-protected virtual void UnbindAngularVelocityActions()
-```
-
-#### UnbindVelocityActions()
-
-Unbinds the velocity performed and canceled actions from the processing methods.
-
-##### Declaration
-
-```
-protected virtual void UnbindVelocityActions()
-```
-
-#### VelocityActionCanceled(InputAction.CallbackContext)
-
-Processes the context when the velocity InputActionProperty is canceled.
-
-##### Declaration
-
-```
-protected virtual void VelocityActionCanceled(InputAction.CallbackContext context)
-```
-
-##### Parameters
-
-| Type | Name | Description |
-| --- | --- | --- |
-| InputAction.CallbackContext | context | The action context data. |
-
-#### VelocityActionPerformed(InputAction.CallbackContext)
-
-Processes the context when the velocity InputActionProperty is performed.
-
-##### Declaration
-
-```
-protected virtual void VelocityActionPerformed(InputAction.CallbackContext context)
-```
-
-##### Parameters
-
-| Type | Name | Description |
-| --- | --- | --- |
-| InputAction.CallbackContext | context | The action context data. |
-
 [Tilia.Input.UnityInputSystem.Tracking.Velocity]: README.md
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
@@ -279,21 +108,8 @@ protected virtual void VelocityActionPerformed(InputAction.CallbackContext conte
 [Fields]: #Fields
 [currentAngularVelocity]: #currentAngularVelocity
 [currentVelocity]: #currentVelocity
-[Properties]: #Properties
-[AngularVelocitySource]: #AngularVelocitySource
-[VelocitySource]: #VelocitySource
 [Methods]: #Methods
-[AngularVelocityActionCanceled(InputAction.CallbackContext)]: #AngularVelocityActionCanceledInputAction.CallbackContext
-[AngularVelocityActionPerformed(InputAction.CallbackContext)]: #AngularVelocityActionPerformedInputAction.CallbackContext
-[BindAngularVelocityActions()]: #BindAngularVelocityActions
-[BindVelocityActions()]: #BindVelocityActions
-[DisableAction(InputActionProperty)]: #DisableActionInputActionProperty
 [DoGetAngularVelocity()]: #DoGetAngularVelocity
 [DoGetVelocity()]: #DoGetVelocity
-[EnableAction(InputActionProperty)]: #EnableActionInputActionProperty
 [OnDisable()]: #OnDisable
 [OnEnable()]: #OnEnable
-[UnbindAngularVelocityActions()]: #UnbindAngularVelocityActions
-[UnbindVelocityActions()]: #UnbindVelocityActions
-[VelocityActionCanceled(InputAction.CallbackContext)]: #VelocityActionCanceledInputAction.CallbackContext
-[VelocityActionPerformed(InputAction.CallbackContext)]: #VelocityActionPerformedInputAction.CallbackContext

--- a/Documentation/API/Transformation/Conversion/CallbackContextToBoolean.md
+++ b/Documentation/API/Transformation/Conversion/CallbackContextToBoolean.md
@@ -2,32 +2,17 @@
 
 Transforms a InputAction.CallbackContext to a System.Boolean.
 
-## Contents
-
-* [Inheritance]
-* [Namespace]
-* [Syntax]
-* [Methods]
-  * [Process(InputAction.CallbackContext)]
-
-## Details
-
 ##### Inheritance
 
 * System.Object
-* [InputSystemTransformer]<InputAction.CallbackContext, System.Boolean, [CallbackContextToBoolean.UnityEvent]\>
 * [CallbackContextTransformer]<System.Boolean, [CallbackContextToBoolean.UnityEvent]\>
 * CallbackContextToBoolean
 
 ##### Inherited Members
 
-[CallbackContextTransformer<Boolean, CallbackContextToBoolean.UnityEvent>.ProcessResult(InputAction.CallbackContext)]
+[CallbackContextTransformer<Boolean, CallbackContextToBoolean.UnityEvent>.OnEnable()]
 
-[InputSystemTransformer<InputAction.CallbackContext, Boolean, CallbackContextToBoolean.UnityEvent>.ContextToProcess]
-
-##### Namespace
-
-* [Tilia.Input.UnityInputSystem.Transformation.Conversion]
+###### **Namespace**: [Tilia.Input.UnityInputSystem.Transformation.Conversion]
 
 ##### Syntax
 
@@ -35,38 +20,7 @@ Transforms a InputAction.CallbackContext to a System.Boolean.
 public class CallbackContextToBoolean : CallbackContextTransformer<bool, CallbackContextToBoolean.UnityEvent>
 ```
 
-### Methods
-
-#### Process(InputAction.CallbackContext)
-
-Transforms the given input InputAction.CallbackContext to the equivalent System.Boolean value.
-
-##### Declaration
-
-```
-protected override bool Process(InputAction.CallbackContext input)
-```
-
-##### Parameters
-
-| Type | Name | Description |
-| --- | --- | --- |
-| InputAction.CallbackContext | input | The value to transform. |
-
-##### Returns
-
-| Type | Description |
-| --- | --- |
-| System.Boolean | The transformed value. |
-
-[InputSystemTransformer]: InputSystemTransformer-3.md
 [CallbackContextTransformer]: CallbackContextTransformer-2.md
 [CallbackContextToBoolean.UnityEvent]: CallbackContextToBoolean.UnityEvent.md
-[CallbackContextTransformer<Boolean, CallbackContextToBoolean.UnityEvent>.ProcessResult(InputAction.CallbackContext)]: CallbackContextTransformer-2.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_CallbackContextTransformer_2_ProcessResult_InputAction_CallbackContext_
-[InputSystemTransformer<InputAction.CallbackContext, Boolean, CallbackContextToBoolean.UnityEvent>.ContextToProcess]: InputSystemTransformer-3.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_InputSystemTransformer_3_ContextToProcess
+[CallbackContextTransformer<Boolean, CallbackContextToBoolean.UnityEvent>.OnEnable()]: CallbackContextTransformer-2.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_CallbackContextTransformer_2_OnEnable
 [Tilia.Input.UnityInputSystem.Transformation.Conversion]: README.md
-[Inheritance]: #Inheritance
-[Namespace]: #Namespace
-[Syntax]: #Syntax
-[Methods]: #Methods
-[Process(InputAction.CallbackContext)]: #ProcessInputAction.CallbackContext

--- a/Documentation/API/Transformation/Conversion/CallbackContextToFloat.md
+++ b/Documentation/API/Transformation/Conversion/CallbackContextToFloat.md
@@ -2,32 +2,17 @@
 
 Transforms a InputAction.CallbackContext to a System.Single.
 
-## Contents
-
-* [Inheritance]
-* [Namespace]
-* [Syntax]
-* [Methods]
-  * [Process(InputAction.CallbackContext)]
-
-## Details
-
 ##### Inheritance
 
 * System.Object
-* [InputSystemTransformer]<InputAction.CallbackContext, System.Single, [CallbackContextToFloat.UnityEvent]\>
 * [CallbackContextTransformer]<System.Single, [CallbackContextToFloat.UnityEvent]\>
 * CallbackContextToFloat
 
 ##### Inherited Members
 
-[CallbackContextTransformer<Single, CallbackContextToFloat.UnityEvent>.ProcessResult(InputAction.CallbackContext)]
+[CallbackContextTransformer<Single, CallbackContextToFloat.UnityEvent>.OnEnable()]
 
-[InputSystemTransformer<InputAction.CallbackContext, Single, CallbackContextToFloat.UnityEvent>.ContextToProcess]
-
-##### Namespace
-
-* [Tilia.Input.UnityInputSystem.Transformation.Conversion]
+###### **Namespace**: [Tilia.Input.UnityInputSystem.Transformation.Conversion]
 
 ##### Syntax
 
@@ -35,38 +20,7 @@ Transforms a InputAction.CallbackContext to a System.Single.
 public class CallbackContextToFloat : CallbackContextTransformer<float, CallbackContextToFloat.UnityEvent>
 ```
 
-### Methods
-
-#### Process(InputAction.CallbackContext)
-
-Transforms the given input InputAction.CallbackContext to the equivalent System.Single value.
-
-##### Declaration
-
-```
-protected override float Process(InputAction.CallbackContext input)
-```
-
-##### Parameters
-
-| Type | Name | Description |
-| --- | --- | --- |
-| InputAction.CallbackContext | input | The value to transform. |
-
-##### Returns
-
-| Type | Description |
-| --- | --- |
-| System.Single | The transformed value. |
-
-[InputSystemTransformer]: InputSystemTransformer-3.md
 [CallbackContextTransformer]: CallbackContextTransformer-2.md
 [CallbackContextToFloat.UnityEvent]: CallbackContextToFloat.UnityEvent.md
-[CallbackContextTransformer<Single, CallbackContextToFloat.UnityEvent>.ProcessResult(InputAction.CallbackContext)]: CallbackContextTransformer-2.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_CallbackContextTransformer_2_ProcessResult_InputAction_CallbackContext_
-[InputSystemTransformer<InputAction.CallbackContext, Single, CallbackContextToFloat.UnityEvent>.ContextToProcess]: InputSystemTransformer-3.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_InputSystemTransformer_3_ContextToProcess
+[CallbackContextTransformer<Single, CallbackContextToFloat.UnityEvent>.OnEnable()]: CallbackContextTransformer-2.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_CallbackContextTransformer_2_OnEnable
 [Tilia.Input.UnityInputSystem.Transformation.Conversion]: README.md
-[Inheritance]: #Inheritance
-[Namespace]: #Namespace
-[Syntax]: #Syntax
-[Methods]: #Methods
-[Process(InputAction.CallbackContext)]: #ProcessInputAction.CallbackContext

--- a/Documentation/API/Transformation/Conversion/CallbackContextToVector2.md
+++ b/Documentation/API/Transformation/Conversion/CallbackContextToVector2.md
@@ -2,32 +2,17 @@
 
 Transforms a InputAction.CallbackContext to a Vector2.
 
-## Contents
-
-* [Inheritance]
-* [Namespace]
-* [Syntax]
-* [Methods]
-  * [Process(InputAction.CallbackContext)]
-
-## Details
-
 ##### Inheritance
 
 * System.Object
-* [InputSystemTransformer]<InputAction.CallbackContext, Vector2, [CallbackContextToVector2.UnityEvent]\>
 * [CallbackContextTransformer]<Vector2, [CallbackContextToVector2.UnityEvent]\>
 * CallbackContextToVector2
 
 ##### Inherited Members
 
-[CallbackContextTransformer<Vector2, CallbackContextToVector2.UnityEvent>.ProcessResult(InputAction.CallbackContext)]
+[CallbackContextTransformer<Vector2, CallbackContextToVector2.UnityEvent>.OnEnable()]
 
-[InputSystemTransformer<InputAction.CallbackContext, Vector2, CallbackContextToVector2.UnityEvent>.ContextToProcess]
-
-##### Namespace
-
-* [Tilia.Input.UnityInputSystem.Transformation.Conversion]
+###### **Namespace**: [Tilia.Input.UnityInputSystem.Transformation.Conversion]
 
 ##### Syntax
 
@@ -35,38 +20,7 @@ Transforms a InputAction.CallbackContext to a Vector2.
 public class CallbackContextToVector2 : CallbackContextTransformer<Vector2, CallbackContextToVector2.UnityEvent>
 ```
 
-### Methods
-
-#### Process(InputAction.CallbackContext)
-
-Transforms the given input InputAction.CallbackContext to the equivalent Vector2 value.
-
-##### Declaration
-
-```
-protected override Vector2 Process(InputAction.CallbackContext input)
-```
-
-##### Parameters
-
-| Type | Name | Description |
-| --- | --- | --- |
-| InputAction.CallbackContext | input | The value to transform. |
-
-##### Returns
-
-| Type | Description |
-| --- | --- |
-| Vector2 | The transformed value. |
-
-[InputSystemTransformer]: InputSystemTransformer-3.md
 [CallbackContextTransformer]: CallbackContextTransformer-2.md
 [CallbackContextToVector2.UnityEvent]: CallbackContextToVector2.UnityEvent.md
-[CallbackContextTransformer<Vector2, CallbackContextToVector2.UnityEvent>.ProcessResult(InputAction.CallbackContext)]: CallbackContextTransformer-2.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_CallbackContextTransformer_2_ProcessResult_InputAction_CallbackContext_
-[InputSystemTransformer<InputAction.CallbackContext, Vector2, CallbackContextToVector2.UnityEvent>.ContextToProcess]: InputSystemTransformer-3.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_InputSystemTransformer_3_ContextToProcess
+[CallbackContextTransformer<Vector2, CallbackContextToVector2.UnityEvent>.OnEnable()]: CallbackContextTransformer-2.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_CallbackContextTransformer_2_OnEnable
 [Tilia.Input.UnityInputSystem.Transformation.Conversion]: README.md
-[Inheritance]: #Inheritance
-[Namespace]: #Namespace
-[Syntax]: #Syntax
-[Methods]: #Methods
-[Process(InputAction.CallbackContext)]: #ProcessInputAction.CallbackContext

--- a/Documentation/API/Transformation/Conversion/CallbackContextToVector3.md
+++ b/Documentation/API/Transformation/Conversion/CallbackContextToVector3.md
@@ -2,32 +2,17 @@
 
 Transforms a InputAction.CallbackContext to a Vector3.
 
-## Contents
-
-* [Inheritance]
-* [Namespace]
-* [Syntax]
-* [Methods]
-  * [Process(InputAction.CallbackContext)]
-
-## Details
-
 ##### Inheritance
 
 * System.Object
-* [InputSystemTransformer]<InputAction.CallbackContext, Vector3, [CallbackContextToVector3.UnityEvent]\>
 * [CallbackContextTransformer]<Vector3, [CallbackContextToVector3.UnityEvent]\>
 * CallbackContextToVector3
 
 ##### Inherited Members
 
-[CallbackContextTransformer<Vector3, CallbackContextToVector3.UnityEvent>.ProcessResult(InputAction.CallbackContext)]
+[CallbackContextTransformer<Vector3, CallbackContextToVector3.UnityEvent>.OnEnable()]
 
-[InputSystemTransformer<InputAction.CallbackContext, Vector3, CallbackContextToVector3.UnityEvent>.ContextToProcess]
-
-##### Namespace
-
-* [Tilia.Input.UnityInputSystem.Transformation.Conversion]
+###### **Namespace**: [Tilia.Input.UnityInputSystem.Transformation.Conversion]
 
 ##### Syntax
 
@@ -35,38 +20,7 @@ Transforms a InputAction.CallbackContext to a Vector3.
 public class CallbackContextToVector3 : CallbackContextTransformer<Vector3, CallbackContextToVector3.UnityEvent>
 ```
 
-### Methods
-
-#### Process(InputAction.CallbackContext)
-
-Transforms the given input InputAction.CallbackContext to the equivalent Vector3 value.
-
-##### Declaration
-
-```
-protected override Vector3 Process(InputAction.CallbackContext input)
-```
-
-##### Parameters
-
-| Type | Name | Description |
-| --- | --- | --- |
-| InputAction.CallbackContext | input | The value to transform. |
-
-##### Returns
-
-| Type | Description |
-| --- | --- |
-| Vector3 | The transformed value. |
-
-[InputSystemTransformer]: InputSystemTransformer-3.md
 [CallbackContextTransformer]: CallbackContextTransformer-2.md
 [CallbackContextToVector3.UnityEvent]: CallbackContextToVector3.UnityEvent.md
-[CallbackContextTransformer<Vector3, CallbackContextToVector3.UnityEvent>.ProcessResult(InputAction.CallbackContext)]: CallbackContextTransformer-2.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_CallbackContextTransformer_2_ProcessResult_InputAction_CallbackContext_
-[InputSystemTransformer<InputAction.CallbackContext, Vector3, CallbackContextToVector3.UnityEvent>.ContextToProcess]: InputSystemTransformer-3.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_InputSystemTransformer_3_ContextToProcess
+[CallbackContextTransformer<Vector3, CallbackContextToVector3.UnityEvent>.OnEnable()]: CallbackContextTransformer-2.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_CallbackContextTransformer_2_OnEnable
 [Tilia.Input.UnityInputSystem.Transformation.Conversion]: README.md
-[Inheritance]: #Inheritance
-[Namespace]: #Namespace
-[Syntax]: #Syntax
-[Methods]: #Methods
-[Process(InputAction.CallbackContext)]: #ProcessInputAction.CallbackContext

--- a/Documentation/API/Transformation/Conversion/CallbackContextTransformer-2.md
+++ b/Documentation/API/Transformation/Conversion/CallbackContextTransformer-2.md
@@ -1,30 +1,23 @@
 # Class CallbackContextTransformer<TOutput, TEvent>
 
-Provides an abstract base to transform a given InputAction.CallbackContext to the TOutput data type.
-
 ## Contents
 
 * [Inheritance]
 * [Namespace]
 * [Syntax]
 * [Methods]
-  * [ProcessResult(InputAction.CallbackContext)]
+  * [OnEnable()]
 
 ## Details
 
 ##### Inheritance
 
 * System.Object
-* [InputSystemTransformer]<InputAction.CallbackContext, TOutput, TEvent>
 * CallbackContextTransformer<TOutput, TEvent>
 * [CallbackContextToBoolean]
 * [CallbackContextToFloat]
 * [CallbackContextToVector2]
 * [CallbackContextToVector3]
-
-##### Inherited Members
-
-[InputSystemTransformer<InputAction.CallbackContext, TOutput, TEvent>.ContextToProcess]
 
 ##### Namespace
 
@@ -33,49 +26,33 @@ Provides an abstract base to transform a given InputAction.CallbackContext to th
 ##### Syntax
 
 ```
-public abstract class CallbackContextTransformer<TOutput, TEvent> : InputSystemTransformer<InputAction.CallbackContext, TOutput, TEvent> where TEvent : UnityEvent<TOutput>, new()
+public abstract class CallbackContextTransformer<TOutput, TEvent> : UnityEngine.MonoBehaviour
 ```
 
 ##### Type Parameters
 
 | Name | Description |
 | --- | --- |
-| TOutput | The variable type that will be output from the result of the transformation. |
-| TEvent | The UnityEvent type the transformation will emit. |
+| TOutput | n/a |
+| TEvent | n/a |
 
 ### Methods
 
-#### ProcessResult(InputAction.CallbackContext)
-
-Processes the given input into the output result as long as the context event is allowed to be processed based on the ContextToProcess value.
+#### OnEnable()
 
 ##### Declaration
 
 ```
-protected override TOutput ProcessResult(InputAction.CallbackContext input)
+protected virtual void OnEnable()
 ```
 
-##### Parameters
-
-| Type | Name | Description |
-| --- | --- | --- |
-| InputAction.CallbackContext | input | The value to transform. |
-
-##### Returns
-
-| Type | Description |
-| --- | --- |
-| TOutput | The transformed value. |
-
-[InputSystemTransformer]: InputSystemTransformer-3.md
 [CallbackContextToBoolean]: CallbackContextToBoolean.md
 [CallbackContextToFloat]: CallbackContextToFloat.md
 [CallbackContextToVector2]: CallbackContextToVector2.md
 [CallbackContextToVector3]: CallbackContextToVector3.md
-[InputSystemTransformer<InputAction.CallbackContext, TOutput, TEvent>.ContextToProcess]: InputSystemTransformer-3.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_InputSystemTransformer_3_ContextToProcess
 [Tilia.Input.UnityInputSystem.Transformation.Conversion]: README.md
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
 [Syntax]: #Syntax
 [Methods]: #Methods
-[ProcessResult(InputAction.CallbackContext)]: #ProcessResultInputAction.CallbackContext
+[OnEnable()]: #OnEnable

--- a/Documentation/API/Transformation/Conversion/InputActionPropertyToBoolean.md
+++ b/Documentation/API/Transformation/Conversion/InputActionPropertyToBoolean.md
@@ -2,42 +2,17 @@
 
 Transforms a InputActionProperty to a System.Boolean.
 
-## Contents
-
-* [Inheritance]
-* [Namespace]
-* [Syntax]
-* [Methods]
-  * [Process(InputAction)]
-
-## Details
-
 ##### Inheritance
 
 * System.Object
-* [InputSystemTransformer]<InputAction, System.Boolean, [InputActionPropertyToBoolean.UnityEvent]\>
 * [InputActionPropertyTransformer]<System.Boolean, [InputActionPropertyToBoolean.UnityEvent]\>
 * InputActionPropertyToBoolean
 
 ##### Inherited Members
 
-[InputActionPropertyTransformer<Boolean, InputActionPropertyToBoolean.UnityEvent>.Source]
-
 [InputActionPropertyTransformer<Boolean, InputActionPropertyToBoolean.UnityEvent>.OnEnable()]
 
-[InputActionPropertyTransformer<Boolean, InputActionPropertyToBoolean.UnityEvent>.OnDisable()]
-
-[InputActionPropertyTransformer<Boolean, InputActionPropertyToBoolean.UnityEvent>.BindActions()]
-
-[InputActionPropertyTransformer<Boolean, InputActionPropertyToBoolean.UnityEvent>.UnbindActions()]
-
-[InputActionPropertyTransformer<Boolean, InputActionPropertyToBoolean.UnityEvent>.ProcessAction(InputAction.CallbackContext)]
-
-[InputSystemTransformer<InputAction, Boolean, InputActionPropertyToBoolean.UnityEvent>.ContextToProcess]
-
-##### Namespace
-
-* [Tilia.Input.UnityInputSystem.Transformation.Conversion]
+###### **Namespace**: [Tilia.Input.UnityInputSystem.Transformation.Conversion]
 
 ##### Syntax
 
@@ -45,41 +20,7 @@ Transforms a InputActionProperty to a System.Boolean.
 public class InputActionPropertyToBoolean : InputActionPropertyTransformer<bool, InputActionPropertyToBoolean.UnityEvent>
 ```
 
-### Methods
-
-#### Process(InputAction)
-
-##### Declaration
-
-```
-protected override bool Process(InputAction action)
-```
-
-##### Parameters
-
-| Type | Name | Description |
-| --- | --- | --- |
-| InputAction | action | n/a |
-
-##### Returns
-
-| Type | Description |
-| --- | --- |
-| System.Boolean | n/a |
-
-[InputSystemTransformer]: InputSystemTransformer-3.md
 [InputActionPropertyTransformer]: InputActionPropertyTransformer-2.md
 [InputActionPropertyToBoolean.UnityEvent]: InputActionPropertyToBoolean.UnityEvent.md
-[InputActionPropertyTransformer<Boolean, InputActionPropertyToBoolean.UnityEvent>.Source]: InputActionPropertyTransformer-2.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_InputActionPropertyTransformer_2_Source
 [InputActionPropertyTransformer<Boolean, InputActionPropertyToBoolean.UnityEvent>.OnEnable()]: InputActionPropertyTransformer-2.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_InputActionPropertyTransformer_2_OnEnable
-[InputActionPropertyTransformer<Boolean, InputActionPropertyToBoolean.UnityEvent>.OnDisable()]: InputActionPropertyTransformer-2.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_InputActionPropertyTransformer_2_OnDisable
-[InputActionPropertyTransformer<Boolean, InputActionPropertyToBoolean.UnityEvent>.BindActions()]: InputActionPropertyTransformer-2.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_InputActionPropertyTransformer_2_BindActions
-[InputActionPropertyTransformer<Boolean, InputActionPropertyToBoolean.UnityEvent>.UnbindActions()]: InputActionPropertyTransformer-2.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_InputActionPropertyTransformer_2_UnbindActions
-[InputActionPropertyTransformer<Boolean, InputActionPropertyToBoolean.UnityEvent>.ProcessAction(InputAction.CallbackContext)]: InputActionPropertyTransformer-2.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_InputActionPropertyTransformer_2_ProcessAction_InputAction_CallbackContext_
-[InputSystemTransformer<InputAction, Boolean, InputActionPropertyToBoolean.UnityEvent>.ContextToProcess]: InputSystemTransformer-3.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_InputSystemTransformer_3_ContextToProcess
 [Tilia.Input.UnityInputSystem.Transformation.Conversion]: README.md
-[Inheritance]: #Inheritance
-[Namespace]: #Namespace
-[Syntax]: #Syntax
-[Methods]: #Methods
-[Process(InputAction)]: #ProcessInputAction

--- a/Documentation/API/Transformation/Conversion/InputActionPropertyToFloat.md
+++ b/Documentation/API/Transformation/Conversion/InputActionPropertyToFloat.md
@@ -2,42 +2,17 @@
 
 Transforms a InputActionProperty to a System.Single.
 
-## Contents
-
-* [Inheritance]
-* [Namespace]
-* [Syntax]
-* [Methods]
-  * [Process(InputAction)]
-
-## Details
-
 ##### Inheritance
 
 * System.Object
-* [InputSystemTransformer]<InputAction, System.Single, [InputActionPropertyToFloat.UnityEvent]\>
 * [InputActionPropertyTransformer]<System.Single, [InputActionPropertyToFloat.UnityEvent]\>
 * InputActionPropertyToFloat
 
 ##### Inherited Members
 
-[InputActionPropertyTransformer<Single, InputActionPropertyToFloat.UnityEvent>.Source]
-
 [InputActionPropertyTransformer<Single, InputActionPropertyToFloat.UnityEvent>.OnEnable()]
 
-[InputActionPropertyTransformer<Single, InputActionPropertyToFloat.UnityEvent>.OnDisable()]
-
-[InputActionPropertyTransformer<Single, InputActionPropertyToFloat.UnityEvent>.BindActions()]
-
-[InputActionPropertyTransformer<Single, InputActionPropertyToFloat.UnityEvent>.UnbindActions()]
-
-[InputActionPropertyTransformer<Single, InputActionPropertyToFloat.UnityEvent>.ProcessAction(InputAction.CallbackContext)]
-
-[InputSystemTransformer<InputAction, Single, InputActionPropertyToFloat.UnityEvent>.ContextToProcess]
-
-##### Namespace
-
-* [Tilia.Input.UnityInputSystem.Transformation.Conversion]
+###### **Namespace**: [Tilia.Input.UnityInputSystem.Transformation.Conversion]
 
 ##### Syntax
 
@@ -45,41 +20,7 @@ Transforms a InputActionProperty to a System.Single.
 public class InputActionPropertyToFloat : InputActionPropertyTransformer<float, InputActionPropertyToFloat.UnityEvent>
 ```
 
-### Methods
-
-#### Process(InputAction)
-
-##### Declaration
-
-```
-protected override float Process(InputAction action)
-```
-
-##### Parameters
-
-| Type | Name | Description |
-| --- | --- | --- |
-| InputAction | action | n/a |
-
-##### Returns
-
-| Type | Description |
-| --- | --- |
-| System.Single | n/a |
-
-[InputSystemTransformer]: InputSystemTransformer-3.md
 [InputActionPropertyTransformer]: InputActionPropertyTransformer-2.md
 [InputActionPropertyToFloat.UnityEvent]: InputActionPropertyToFloat.UnityEvent.md
-[InputActionPropertyTransformer<Single, InputActionPropertyToFloat.UnityEvent>.Source]: InputActionPropertyTransformer-2.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_InputActionPropertyTransformer_2_Source
 [InputActionPropertyTransformer<Single, InputActionPropertyToFloat.UnityEvent>.OnEnable()]: InputActionPropertyTransformer-2.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_InputActionPropertyTransformer_2_OnEnable
-[InputActionPropertyTransformer<Single, InputActionPropertyToFloat.UnityEvent>.OnDisable()]: InputActionPropertyTransformer-2.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_InputActionPropertyTransformer_2_OnDisable
-[InputActionPropertyTransformer<Single, InputActionPropertyToFloat.UnityEvent>.BindActions()]: InputActionPropertyTransformer-2.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_InputActionPropertyTransformer_2_BindActions
-[InputActionPropertyTransformer<Single, InputActionPropertyToFloat.UnityEvent>.UnbindActions()]: InputActionPropertyTransformer-2.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_InputActionPropertyTransformer_2_UnbindActions
-[InputActionPropertyTransformer<Single, InputActionPropertyToFloat.UnityEvent>.ProcessAction(InputAction.CallbackContext)]: InputActionPropertyTransformer-2.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_InputActionPropertyTransformer_2_ProcessAction_InputAction_CallbackContext_
-[InputSystemTransformer<InputAction, Single, InputActionPropertyToFloat.UnityEvent>.ContextToProcess]: InputSystemTransformer-3.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_InputSystemTransformer_3_ContextToProcess
 [Tilia.Input.UnityInputSystem.Transformation.Conversion]: README.md
-[Inheritance]: #Inheritance
-[Namespace]: #Namespace
-[Syntax]: #Syntax
-[Methods]: #Methods
-[Process(InputAction)]: #ProcessInputAction

--- a/Documentation/API/Transformation/Conversion/InputActionPropertyToVector2.md
+++ b/Documentation/API/Transformation/Conversion/InputActionPropertyToVector2.md
@@ -2,42 +2,17 @@
 
 Transforms a InputActionProperty to a Vector2.
 
-## Contents
-
-* [Inheritance]
-* [Namespace]
-* [Syntax]
-* [Methods]
-  * [Process(InputAction)]
-
-## Details
-
 ##### Inheritance
 
 * System.Object
-* [InputSystemTransformer]<InputAction, Vector2, [InputActionPropertyToVector2.UnityEvent]\>
 * [InputActionPropertyTransformer]<Vector2, [InputActionPropertyToVector2.UnityEvent]\>
 * InputActionPropertyToVector2
 
 ##### Inherited Members
 
-[InputActionPropertyTransformer<Vector2, InputActionPropertyToVector2.UnityEvent>.Source]
-
 [InputActionPropertyTransformer<Vector2, InputActionPropertyToVector2.UnityEvent>.OnEnable()]
 
-[InputActionPropertyTransformer<Vector2, InputActionPropertyToVector2.UnityEvent>.OnDisable()]
-
-[InputActionPropertyTransformer<Vector2, InputActionPropertyToVector2.UnityEvent>.BindActions()]
-
-[InputActionPropertyTransformer<Vector2, InputActionPropertyToVector2.UnityEvent>.UnbindActions()]
-
-[InputActionPropertyTransformer<Vector2, InputActionPropertyToVector2.UnityEvent>.ProcessAction(InputAction.CallbackContext)]
-
-[InputSystemTransformer<InputAction, Vector2, InputActionPropertyToVector2.UnityEvent>.ContextToProcess]
-
-##### Namespace
-
-* [Tilia.Input.UnityInputSystem.Transformation.Conversion]
+###### **Namespace**: [Tilia.Input.UnityInputSystem.Transformation.Conversion]
 
 ##### Syntax
 
@@ -45,41 +20,7 @@ Transforms a InputActionProperty to a Vector2.
 public class InputActionPropertyToVector2 : InputActionPropertyTransformer<Vector2, InputActionPropertyToVector2.UnityEvent>
 ```
 
-### Methods
-
-#### Process(InputAction)
-
-##### Declaration
-
-```
-protected override Vector2 Process(InputAction action)
-```
-
-##### Parameters
-
-| Type | Name | Description |
-| --- | --- | --- |
-| InputAction | action | n/a |
-
-##### Returns
-
-| Type | Description |
-| --- | --- |
-| Vector2 | n/a |
-
-[InputSystemTransformer]: InputSystemTransformer-3.md
 [InputActionPropertyTransformer]: InputActionPropertyTransformer-2.md
 [InputActionPropertyToVector2.UnityEvent]: InputActionPropertyToVector2.UnityEvent.md
-[InputActionPropertyTransformer<Vector2, InputActionPropertyToVector2.UnityEvent>.Source]: InputActionPropertyTransformer-2.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_InputActionPropertyTransformer_2_Source
 [InputActionPropertyTransformer<Vector2, InputActionPropertyToVector2.UnityEvent>.OnEnable()]: InputActionPropertyTransformer-2.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_InputActionPropertyTransformer_2_OnEnable
-[InputActionPropertyTransformer<Vector2, InputActionPropertyToVector2.UnityEvent>.OnDisable()]: InputActionPropertyTransformer-2.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_InputActionPropertyTransformer_2_OnDisable
-[InputActionPropertyTransformer<Vector2, InputActionPropertyToVector2.UnityEvent>.BindActions()]: InputActionPropertyTransformer-2.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_InputActionPropertyTransformer_2_BindActions
-[InputActionPropertyTransformer<Vector2, InputActionPropertyToVector2.UnityEvent>.UnbindActions()]: InputActionPropertyTransformer-2.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_InputActionPropertyTransformer_2_UnbindActions
-[InputActionPropertyTransformer<Vector2, InputActionPropertyToVector2.UnityEvent>.ProcessAction(InputAction.CallbackContext)]: InputActionPropertyTransformer-2.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_InputActionPropertyTransformer_2_ProcessAction_InputAction_CallbackContext_
-[InputSystemTransformer<InputAction, Vector2, InputActionPropertyToVector2.UnityEvent>.ContextToProcess]: InputSystemTransformer-3.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_InputSystemTransformer_3_ContextToProcess
 [Tilia.Input.UnityInputSystem.Transformation.Conversion]: README.md
-[Inheritance]: #Inheritance
-[Namespace]: #Namespace
-[Syntax]: #Syntax
-[Methods]: #Methods
-[Process(InputAction)]: #ProcessInputAction

--- a/Documentation/API/Transformation/Conversion/InputActionPropertyToVector3.md
+++ b/Documentation/API/Transformation/Conversion/InputActionPropertyToVector3.md
@@ -2,42 +2,17 @@
 
 Transforms a InputActionProperty to a Vector3.
 
-## Contents
-
-* [Inheritance]
-* [Namespace]
-* [Syntax]
-* [Methods]
-  * [Process(InputAction)]
-
-## Details
-
 ##### Inheritance
 
 * System.Object
-* [InputSystemTransformer]<InputAction, Vector3, [InputActionPropertyToVector3.UnityEvent]\>
 * [InputActionPropertyTransformer]<Vector3, [InputActionPropertyToVector3.UnityEvent]\>
 * InputActionPropertyToVector3
 
 ##### Inherited Members
 
-[InputActionPropertyTransformer<Vector3, InputActionPropertyToVector3.UnityEvent>.Source]
-
 [InputActionPropertyTransformer<Vector3, InputActionPropertyToVector3.UnityEvent>.OnEnable()]
 
-[InputActionPropertyTransformer<Vector3, InputActionPropertyToVector3.UnityEvent>.OnDisable()]
-
-[InputActionPropertyTransformer<Vector3, InputActionPropertyToVector3.UnityEvent>.BindActions()]
-
-[InputActionPropertyTransformer<Vector3, InputActionPropertyToVector3.UnityEvent>.UnbindActions()]
-
-[InputActionPropertyTransformer<Vector3, InputActionPropertyToVector3.UnityEvent>.ProcessAction(InputAction.CallbackContext)]
-
-[InputSystemTransformer<InputAction, Vector3, InputActionPropertyToVector3.UnityEvent>.ContextToProcess]
-
-##### Namespace
-
-* [Tilia.Input.UnityInputSystem.Transformation.Conversion]
+###### **Namespace**: [Tilia.Input.UnityInputSystem.Transformation.Conversion]
 
 ##### Syntax
 
@@ -45,41 +20,7 @@ Transforms a InputActionProperty to a Vector3.
 public class InputActionPropertyToVector3 : InputActionPropertyTransformer<Vector3, InputActionPropertyToVector3.UnityEvent>
 ```
 
-### Methods
-
-#### Process(InputAction)
-
-##### Declaration
-
-```
-protected override Vector3 Process(InputAction action)
-```
-
-##### Parameters
-
-| Type | Name | Description |
-| --- | --- | --- |
-| InputAction | action | n/a |
-
-##### Returns
-
-| Type | Description |
-| --- | --- |
-| Vector3 | n/a |
-
-[InputSystemTransformer]: InputSystemTransformer-3.md
 [InputActionPropertyTransformer]: InputActionPropertyTransformer-2.md
 [InputActionPropertyToVector3.UnityEvent]: InputActionPropertyToVector3.UnityEvent.md
-[InputActionPropertyTransformer<Vector3, InputActionPropertyToVector3.UnityEvent>.Source]: InputActionPropertyTransformer-2.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_InputActionPropertyTransformer_2_Source
 [InputActionPropertyTransformer<Vector3, InputActionPropertyToVector3.UnityEvent>.OnEnable()]: InputActionPropertyTransformer-2.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_InputActionPropertyTransformer_2_OnEnable
-[InputActionPropertyTransformer<Vector3, InputActionPropertyToVector3.UnityEvent>.OnDisable()]: InputActionPropertyTransformer-2.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_InputActionPropertyTransformer_2_OnDisable
-[InputActionPropertyTransformer<Vector3, InputActionPropertyToVector3.UnityEvent>.BindActions()]: InputActionPropertyTransformer-2.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_InputActionPropertyTransformer_2_BindActions
-[InputActionPropertyTransformer<Vector3, InputActionPropertyToVector3.UnityEvent>.UnbindActions()]: InputActionPropertyTransformer-2.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_InputActionPropertyTransformer_2_UnbindActions
-[InputActionPropertyTransformer<Vector3, InputActionPropertyToVector3.UnityEvent>.ProcessAction(InputAction.CallbackContext)]: InputActionPropertyTransformer-2.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_InputActionPropertyTransformer_2_ProcessAction_InputAction_CallbackContext_
-[InputSystemTransformer<InputAction, Vector3, InputActionPropertyToVector3.UnityEvent>.ContextToProcess]: InputSystemTransformer-3.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_InputSystemTransformer_3_ContextToProcess
 [Tilia.Input.UnityInputSystem.Transformation.Conversion]: README.md
-[Inheritance]: #Inheritance
-[Namespace]: #Namespace
-[Syntax]: #Syntax
-[Methods]: #Methods
-[Process(InputAction)]: #ProcessInputAction

--- a/Documentation/API/Transformation/Conversion/InputActionPropertyTransformer-2.md
+++ b/Documentation/API/Transformation/Conversion/InputActionPropertyTransformer-2.md
@@ -1,36 +1,23 @@
 # Class InputActionPropertyTransformer<TOutput, TEvent>
 
-Provides an abstract base to transform a given InputAction to the TOutput data type.
-
 ## Contents
 
 * [Inheritance]
 * [Namespace]
 * [Syntax]
-* [Properties]
-  * [Source]
 * [Methods]
-  * [BindActions()]
-  * [OnDisable()]
   * [OnEnable()]
-  * [ProcessAction(InputAction.CallbackContext)]
-  * [UnbindActions()]
 
 ## Details
 
 ##### Inheritance
 
 * System.Object
-* [InputSystemTransformer]<InputAction, TOutput, TEvent>
 * InputActionPropertyTransformer<TOutput, TEvent>
 * [InputActionPropertyToBoolean]
 * [InputActionPropertyToFloat]
 * [InputActionPropertyToVector2]
 * [InputActionPropertyToVector3]
-
-##### Inherited Members
-
-[InputSystemTransformer<InputAction, TOutput, TEvent>.ContextToProcess]
 
 ##### Namespace
 
@@ -39,47 +26,17 @@ Provides an abstract base to transform a given InputAction to the TOutput data t
 ##### Syntax
 
 ```
-public abstract class InputActionPropertyTransformer<TOutput, TEvent> : InputSystemTransformer<InputAction, TOutput, TEvent> where TEvent : UnityEvent<TOutput>, new()
+public abstract class InputActionPropertyTransformer<TOutput, TEvent> : MonoBehaviour
 ```
 
 ##### Type Parameters
 
 | Name | Description |
 | --- | --- |
-| TOutput | The variable type that will be output from the result of the transformation. |
-| TEvent | The UnityEvent type the transformation will emit. |
-
-### Properties
-
-#### Source
-
-The InputAction source.
-
-##### Declaration
-
-```
-public InputActionProperty Source { get; set; }
-```
+| TOutput | n/a |
+| TEvent | n/a |
 
 ### Methods
-
-#### BindActions()
-
-Binds the [Source] actions to the appropriate ContextToProcess type.
-
-##### Declaration
-
-```
-protected virtual void BindActions()
-```
-
-#### OnDisable()
-
-##### Declaration
-
-```
-protected virtual void OnDisable()
-```
 
 #### OnEnable()
 
@@ -89,49 +46,13 @@ protected virtual void OnDisable()
 protected virtual void OnEnable()
 ```
 
-#### ProcessAction(InputAction.CallbackContext)
-
-Processes the given action to transform it.
-
-##### Declaration
-
-```
-protected virtual void ProcessAction(InputAction.CallbackContext context)
-```
-
-##### Parameters
-
-| Type | Name | Description |
-| --- | --- | --- |
-| InputAction.CallbackContext | context | The context to process. |
-
-#### UnbindActions()
-
-Unbinds the [Source] actions from the appropriate ContextToProcess type.
-
-##### Declaration
-
-```
-protected virtual void UnbindActions()
-```
-
-[InputSystemTransformer]: InputSystemTransformer-3.md
 [InputActionPropertyToBoolean]: InputActionPropertyToBoolean.md
 [InputActionPropertyToFloat]: InputActionPropertyToFloat.md
 [InputActionPropertyToVector2]: InputActionPropertyToVector2.md
 [InputActionPropertyToVector3]: InputActionPropertyToVector3.md
-[InputSystemTransformer<InputAction, TOutput, TEvent>.ContextToProcess]: InputSystemTransformer-3.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_InputSystemTransformer_3_ContextToProcess
 [Tilia.Input.UnityInputSystem.Transformation.Conversion]: README.md
-[Source]: InputActionPropertyTransformer-2.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_InputActionPropertyTransformer_2_Source
-[Source]: InputActionPropertyTransformer-2.md#Tilia_Input_UnityInputSystem_Transformation_Conversion_InputActionPropertyTransformer_2_Source
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
 [Syntax]: #Syntax
-[Properties]: #Properties
-[Source]: #Source
 [Methods]: #Methods
-[BindActions()]: #BindActions
-[OnDisable()]: #OnDisable
 [OnEnable()]: #OnEnable
-[ProcessAction(InputAction.CallbackContext)]: #ProcessActionInputAction.CallbackContext
-[UnbindActions()]: #UnbindActions

--- a/Documentation/API/Transformation/Conversion/InputSystemTransformer-3.ContextType.md
+++ b/Documentation/API/Transformation/Conversion/InputSystemTransformer-3.ContextType.md
@@ -9,7 +9,7 @@
 
 # Enum InputSystemTransformer<TInput, TOutput, TEvent>.ContextType
 
-The InputAction.CallbackContext event context.
+The UnityEngine.InputSystem.InputAction.CallbackContext event context.
 
 ##### Namespace
 

--- a/Documentation/API/Transformation/Conversion/InputSystemTransformer-3.md
+++ b/Documentation/API/Transformation/Conversion/InputSystemTransformer-3.md
@@ -16,8 +16,6 @@ Provides an abstract base to transform a given Unity Input System TInput type to
 
 * System.Object
 * InputSystemTransformer<TInput, TOutput, TEvent>
-* [CallbackContextTransformer<TOutput, TEvent>]
-* [InputActionPropertyTransformer<TOutput, TEvent>]
 
 ##### Namespace
 
@@ -49,8 +47,6 @@ The [InputSystemTransformer<TInput, TOutput, TEvent>.ContextType] event to proce
 public InputSystemTransformer<TInput, TOutput, TEvent>.ContextType ContextToProcess { get; set; }
 ```
 
-[CallbackContextTransformer<TOutput, TEvent>]: CallbackContextTransformer-2.md
-[InputActionPropertyTransformer<TOutput, TEvent>]: InputActionPropertyTransformer-2.md
 [Tilia.Input.UnityInputSystem.Transformation.Conversion]: README.md
 [InputSystemTransformer<TInput, TOutput, TEvent>.ContextType]: InputSystemTransformer-3.ContextType.md
 [InputSystemTransformer.ContextType]: InputSystemTransformer-3.ContextType.md

--- a/Documentation/API/Transformation/Conversion/README.md
+++ b/Documentation/API/Transformation/Conversion/README.md
@@ -36,8 +36,6 @@ Defines the event with the transformed Vector3 value.
 
 #### [CallbackContextTransformer<TOutput, TEvent>]
 
-Provides an abstract base to transform a given InputAction.CallbackContext to the TOutput data type.
-
 #### [InputActionPropertyToBoolean]
 
 Transforms a InputActionProperty to a System.Boolean.
@@ -72,8 +70,6 @@ Defines the event with the transformed Vector3 value.
 
 #### [InputActionPropertyTransformer<TOutput, TEvent>]
 
-Provides an abstract base to transform a given InputAction to the TOutput data type.
-
 #### [InputSystemTransformer<TInput, TOutput, TEvent>]
 
 Provides an abstract base to transform a given Unity Input System TInput type to the TOutput data type.
@@ -82,7 +78,7 @@ Provides an abstract base to transform a given Unity Input System TInput type to
 
 #### [InputSystemTransformer<TInput, TOutput, TEvent>.ContextType]
 
-The InputAction.CallbackContext event context.
+The UnityEngine.InputSystem.InputAction.CallbackContext event context.
 
 [CallbackContextToBoolean]: CallbackContextToBoolean.md
 [CallbackContextToBoolean.UnityEvent]: CallbackContextToBoolean.UnityEvent.md

--- a/Runtime/SharedResources/Scripts/Tracking/Velocity/InputActionPropertyVelocityTracker.cs
+++ b/Runtime/SharedResources/Scripts/Tracking/Velocity/InputActionPropertyVelocityTracker.cs
@@ -1,7 +1,9 @@
 namespace Tilia.Input.UnityInputSystem.Tracking.Velocity
 {
     using UnityEngine;
+#if ENABLE_INPUT_SYSTEM
     using UnityEngine.InputSystem;
+#endif
     using Zinnia.Tracking.Velocity;
 
     /// <summary>
@@ -9,6 +11,7 @@ namespace Tilia.Input.UnityInputSystem.Tracking.Velocity
     /// </summary>
     public class InputActionPropertyVelocityTracker : VelocityTracker
     {
+#if ENABLE_INPUT_SYSTEM
         [Tooltip("The InputActionProperty containing the velocity source.")]
         [SerializeField]
         private InputActionProperty velocitySource;
@@ -34,7 +37,9 @@ namespace Tilia.Input.UnityInputSystem.Tracking.Velocity
                 }
             }
         }
+#endif
 
+#if ENABLE_INPUT_SYSTEM
         [Tooltip("The InputActionProperty containing the angular velocity source.")]
         [SerializeField]
         private InputActionProperty angularVelocitySource;
@@ -60,6 +65,7 @@ namespace Tilia.Input.UnityInputSystem.Tracking.Velocity
                 }
             }
         }
+#endif
 
         /// <summary>
         /// The current velocity.
@@ -84,16 +90,24 @@ namespace Tilia.Input.UnityInputSystem.Tracking.Velocity
 
         protected virtual void OnEnable()
         {
+#if ENABLE_INPUT_SYSTEM
             BindVelocityActions();
             BindAngularVelocityActions();
+            Debug.LogWarning("The Unity Input System is disabled in the player settings or not available to this Unity version.");
+#else
+
+#endif
         }
 
         protected virtual void OnDisable()
         {
+#if ENABLE_INPUT_SYSTEM
             UnbindVelocityActions();
             UnbindAngularVelocityActions();
+#endif
         }
 
+#if ENABLE_INPUT_SYSTEM
         /// <summary>
         /// Binds the velocity performed and canceled actions to the processing methods.
         /// </summary>
@@ -213,5 +227,6 @@ namespace Tilia.Input.UnityInputSystem.Tracking.Velocity
         {
             currentAngularVelocity = Vector3.zero;
         }
+#endif
     }
 }

--- a/Runtime/SharedResources/Scripts/Transformation/Conversion/CallbackContextToBoolean.cs
+++ b/Runtime/SharedResources/Scripts/Transformation/Conversion/CallbackContextToBoolean.cs
@@ -2,7 +2,9 @@ namespace Tilia.Input.UnityInputSystem.Transformation.Conversion
 {
     using System;
     using UnityEngine.Events;
+#if ENABLE_INPUT_SYSTEM
     using UnityEngine.InputSystem;
+#endif
 
     /// <summary>
     /// Transforms a <see cref="InputAction.CallbackContext"/> to a <see cref="bool"/>.
@@ -15,6 +17,7 @@ namespace Tilia.Input.UnityInputSystem.Transformation.Conversion
         [Serializable]
         public class UnityEvent : UnityEvent<bool> { }
 
+#if ENABLE_INPUT_SYSTEM
         /// <summary>
         /// Transforms the given input <see cref="InputAction.CallbackContext"/> to the equivalent <see cref="bool"/> value.
         /// </summary>
@@ -24,5 +27,6 @@ namespace Tilia.Input.UnityInputSystem.Transformation.Conversion
         {
             return input.ReadValueAsButton();
         }
+#endif
     }
 }

--- a/Runtime/SharedResources/Scripts/Transformation/Conversion/CallbackContextToFloat.cs
+++ b/Runtime/SharedResources/Scripts/Transformation/Conversion/CallbackContextToFloat.cs
@@ -2,7 +2,9 @@ namespace Tilia.Input.UnityInputSystem.Transformation.Conversion
 {
     using System;
     using UnityEngine.Events;
+#if ENABLE_INPUT_SYSTEM
     using UnityEngine.InputSystem;
+#endif
 
     /// <summary>
     /// Transforms a <see cref="InputAction.CallbackContext"/> to a <see cref="float"/>.
@@ -15,6 +17,7 @@ namespace Tilia.Input.UnityInputSystem.Transformation.Conversion
         [Serializable]
         public class UnityEvent : UnityEvent<float> { }
 
+#if ENABLE_INPUT_SYSTEM
         /// <summary>
         /// Transforms the given input <see cref="InputAction.CallbackContext"/> to the equivalent <see cref="float"/> value.
         /// </summary>
@@ -24,5 +27,6 @@ namespace Tilia.Input.UnityInputSystem.Transformation.Conversion
         {
             return input.ReadValue<float>();
         }
+#endif
     }
 }

--- a/Runtime/SharedResources/Scripts/Transformation/Conversion/CallbackContextToVector2.cs
+++ b/Runtime/SharedResources/Scripts/Transformation/Conversion/CallbackContextToVector2.cs
@@ -3,7 +3,9 @@ namespace Tilia.Input.UnityInputSystem.Transformation.Conversion
     using System;
     using UnityEngine;
     using UnityEngine.Events;
+#if ENABLE_INPUT_SYSTEM
     using UnityEngine.InputSystem;
+#endif
 
     /// <summary>
     /// Transforms a <see cref="InputAction.CallbackContext"/> to a <see cref="Vector2"/>.
@@ -16,6 +18,7 @@ namespace Tilia.Input.UnityInputSystem.Transformation.Conversion
         [Serializable]
         public class UnityEvent : UnityEvent<Vector2> { }
 
+#if ENABLE_INPUT_SYSTEM
         /// <summary>
         /// Transforms the given input <see cref="InputAction.CallbackContext"/> to the equivalent <see cref="Vector2"/> value.
         /// </summary>
@@ -25,5 +28,6 @@ namespace Tilia.Input.UnityInputSystem.Transformation.Conversion
         {
             return input.ReadValue<Vector2>();
         }
+#endif
     }
 }

--- a/Runtime/SharedResources/Scripts/Transformation/Conversion/CallbackContextToVector3.cs
+++ b/Runtime/SharedResources/Scripts/Transformation/Conversion/CallbackContextToVector3.cs
@@ -3,7 +3,9 @@ namespace Tilia.Input.UnityInputSystem.Transformation.Conversion
     using System;
     using UnityEngine;
     using UnityEngine.Events;
+#if ENABLE_INPUT_SYSTEM
     using UnityEngine.InputSystem;
+#endif
 
     /// <summary>
     /// Transforms a <see cref="InputAction.CallbackContext"/> to a <see cref="Vector3"/>.
@@ -16,6 +18,7 @@ namespace Tilia.Input.UnityInputSystem.Transformation.Conversion
         [Serializable]
         public class UnityEvent : UnityEvent<Vector3> { }
 
+#if ENABLE_INPUT_SYSTEM
         /// <summary>
         /// Transforms the given input <see cref="InputAction.CallbackContext"/> to the equivalent <see cref="Vector3"/> value.
         /// </summary>
@@ -25,5 +28,6 @@ namespace Tilia.Input.UnityInputSystem.Transformation.Conversion
         {
             return input.ReadValue<Vector3>();
         }
+#endif
     }
 }

--- a/Runtime/SharedResources/Scripts/Transformation/Conversion/CallbackContextTransformer.cs
+++ b/Runtime/SharedResources/Scripts/Transformation/Conversion/CallbackContextTransformer.cs
@@ -1,5 +1,6 @@
 namespace Tilia.Input.UnityInputSystem.Transformation.Conversion
 {
+#if ENABLE_INPUT_SYSTEM
     using UnityEngine.Events;
     using UnityEngine.InputSystem;
 
@@ -27,4 +28,13 @@ namespace Tilia.Input.UnityInputSystem.Transformation.Conversion
             return base.ProcessResult(input);
         }
     }
+#else
+    public abstract class CallbackContextTransformer<TOutput, TEvent> : UnityEngine.MonoBehaviour
+    {
+        protected virtual void OnEnable()
+        {
+            UnityEngine.Debug.LogWarning("The Unity Input System is disabled in the player settings or not available to this Unity version.");
+        }
+    }
+#endif
 }

--- a/Runtime/SharedResources/Scripts/Transformation/Conversion/InputActionPropertyToBoolean.cs
+++ b/Runtime/SharedResources/Scripts/Transformation/Conversion/InputActionPropertyToBoolean.cs
@@ -2,7 +2,9 @@ namespace Tilia.Input.UnityInputSystem.Transformation.Conversion
 {
     using System;
     using UnityEngine.Events;
+#if ENABLE_INPUT_SYSTEM
     using UnityEngine.InputSystem;
+#endif
 
     /// <summary>
     /// Transforms a <see cref="InputActionProperty"/> to a <see cref="bool"/>.
@@ -15,10 +17,12 @@ namespace Tilia.Input.UnityInputSystem.Transformation.Conversion
         [Serializable]
         public class UnityEvent : UnityEvent<bool> { }
 
+#if ENABLE_INPUT_SYSTEM
         /// <inheritdoc />
         protected override bool Process(InputAction action)
         {
             return action.triggered;
         }
+#endif
     }
 }

--- a/Runtime/SharedResources/Scripts/Transformation/Conversion/InputActionPropertyToFloat.cs
+++ b/Runtime/SharedResources/Scripts/Transformation/Conversion/InputActionPropertyToFloat.cs
@@ -2,7 +2,9 @@ namespace Tilia.Input.UnityInputSystem.Transformation.Conversion
 {
     using System;
     using UnityEngine.Events;
+#if ENABLE_INPUT_SYSTEM
     using UnityEngine.InputSystem;
+#endif
 
     /// <summary>
     /// Transforms a <see cref="InputActionProperty"/> to a <see cref="float"/>.
@@ -15,10 +17,12 @@ namespace Tilia.Input.UnityInputSystem.Transformation.Conversion
         [Serializable]
         public class UnityEvent : UnityEvent<float> { }
 
+#if ENABLE_INPUT_SYSTEM
         /// <inheritdoc />
         protected override float Process(InputAction action)
         {
             return action != null ? action.ReadValue<float>() : default;
         }
+#endif
     }
 }

--- a/Runtime/SharedResources/Scripts/Transformation/Conversion/InputActionPropertyToVector2.cs
+++ b/Runtime/SharedResources/Scripts/Transformation/Conversion/InputActionPropertyToVector2.cs
@@ -3,7 +3,9 @@ namespace Tilia.Input.UnityInputSystem.Transformation.Conversion
     using System;
     using UnityEngine;
     using UnityEngine.Events;
+#if ENABLE_INPUT_SYSTEM
     using UnityEngine.InputSystem;
+#endif
 
     /// <summary>
     /// Transforms a <see cref="InputActionProperty"/> to a <see cref="Vector2"/>.
@@ -16,10 +18,12 @@ namespace Tilia.Input.UnityInputSystem.Transformation.Conversion
         [Serializable]
         public class UnityEvent : UnityEvent<Vector2> { }
 
+#if ENABLE_INPUT_SYSTEM
         /// <inheritdoc />
         protected override Vector2 Process(InputAction action)
         {
             return action != null ? action.ReadValue<Vector2>() : default;
         }
+#endif
     }
 }

--- a/Runtime/SharedResources/Scripts/Transformation/Conversion/InputActionPropertyToVector3.cs
+++ b/Runtime/SharedResources/Scripts/Transformation/Conversion/InputActionPropertyToVector3.cs
@@ -3,7 +3,9 @@ namespace Tilia.Input.UnityInputSystem.Transformation.Conversion
     using System;
     using UnityEngine;
     using UnityEngine.Events;
+#if ENABLE_INPUT_SYSTEM
     using UnityEngine.InputSystem;
+#endif
 
     /// <summary>
     /// Transforms a <see cref="InputActionProperty"/> to a <see cref="Vector3"/>.
@@ -16,10 +18,12 @@ namespace Tilia.Input.UnityInputSystem.Transformation.Conversion
         [Serializable]
         public class UnityEvent : UnityEvent<Vector3> { }
 
+#if ENABLE_INPUT_SYSTEM
         /// <inheritdoc />
         protected override Vector3 Process(InputAction action)
         {
             return action != null ? action.ReadValue<Vector3>() : default;
         }
+#endif
     }
 }

--- a/Runtime/SharedResources/Scripts/Transformation/Conversion/InputActionPropertyTransformer.cs
+++ b/Runtime/SharedResources/Scripts/Transformation/Conversion/InputActionPropertyTransformer.cs
@@ -1,6 +1,7 @@
 namespace Tilia.Input.UnityInputSystem.Transformation.Conversion
 {
     using UnityEngine;
+#if ENABLE_INPUT_SYSTEM
     using UnityEngine.Events;
     using UnityEngine.InputSystem;
 
@@ -114,4 +115,13 @@ namespace Tilia.Input.UnityInputSystem.Transformation.Conversion
             DoTransform(context.action);
         }
     }
+#else
+    public abstract class InputActionPropertyTransformer<TOutput, TEvent> : MonoBehaviour
+    {
+        protected virtual void OnEnable()
+        {
+            Debug.LogWarning("The Unity Input System is disabled in the player settings or not available to this Unity version.");
+        }
+    }
+#endif
 }

--- a/Runtime/SharedResources/Scripts/Transformation/Conversion/InputSytemTransformer.cs
+++ b/Runtime/SharedResources/Scripts/Transformation/Conversion/InputSytemTransformer.cs
@@ -3,7 +3,6 @@ namespace Tilia.Input.UnityInputSystem.Transformation.Conversion
     using System;
     using UnityEngine;
     using UnityEngine.Events;
-    using UnityEngine.InputSystem;
     using Zinnia.Data.Attribute;
     using Zinnia.Data.Type.Transformation;
 
@@ -16,7 +15,7 @@ namespace Tilia.Input.UnityInputSystem.Transformation.Conversion
     public abstract class InputSystemTransformer<TInput, TOutput, TEvent> : Transformer<TInput, TOutput, TEvent> where TEvent : UnityEvent<TOutput>, new()
     {
         /// <summary>
-        /// The <see cref="InputAction.CallbackContext"/> event context.
+        /// The <see cref="UnityEngine.InputSystem.InputAction.CallbackContext"/> event context.
         /// </summary>
         [Flags]
         public enum ContextType


### PR DESCRIPTION
The relevant input system code is now wrapped in ifdefs to only run if the Unity Input System is enabled and therefore will provide a warning if the code is run when it is not enabled.