### PR TITLE
feat(Tracking): only show warning message when input system not enabled

### DIFF
--- a/Runtime/SharedResources/Scripts/Tracking/Velocity/InputActionPropertyVelocityTracker.cs
+++ b/Runtime/SharedResources/Scripts/Tracking/Velocity/InputActionPropertyVelocityTracker.cs
@@ -93,9 +93,8 @@ namespace Tilia.Input.UnityInputSystem.Tracking.Velocity
 #if ENABLE_INPUT_SYSTEM
             BindVelocityActions();
             BindAngularVelocityActions();
-            Debug.LogWarning("The Unity Input System is disabled in the player settings or not available to this Unity version.");
 #else
-
+            Debug.LogWarning("The Unity Input System is disabled in the player settings or not available to this Unity version.");
 #endif
         }
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     },
     "dependencies": {
         "io.extendreality.zinnia.unity": "2.7.0",
-        "com.unity.inputsystem": "1.0.2"
+        "com.unity.inputsystem": "1.5.0"
     },
     "samples": [
         {


### PR DESCRIPTION
The debug warning message was being shown in the velocity tracker only when the input system was enabled, whereas it should only be shown when the input system is disabled.