### PR TITLE
fix(Samples): provide correct right primary button touch action - fixes #56

### DIFF
--- a/Samples~/GenericXR/UnityInputSystem.InputActionMappings.GenericXR.prefab
+++ b/Samples~/GenericXR/UnityInputSystem.InputActionMappings.GenericXR.prefab
@@ -4368,7 +4368,7 @@ MonoBehaviour:
       m_Interactions: 
       m_SingletonActionBindings: []
       m_Flags: 0
-    m_Reference: {fileID: 2989475458954988438, guid: 4ad928a61d9612a4685b1d2ab5c52c85, type: 3}
+    m_Reference: {fileID: -5418597723381431887, guid: 4ad928a61d9612a4685b1d2ab5c52c85, type: 3}
 --- !u!1 &2884100002522498369
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
The RightPrimaryButton_Touch action was mapped to the left primary button touch action, this has now been corrected.